### PR TITLE
Skip invalid format IP to prevent from interrupting the event flow

### DIFF
--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -109,7 +109,14 @@ module Fluent
       ip = record[@lookup_field]
 
       unless ip.nil? then
-        geoip = @database.lookup(ip)
+
+        geoip = {}
+        begin
+          geoip = @database.lookup(ip)
+        rescue IPAddr::InvalidAddressError => e
+          # Do nothing if if InvalidAddressError
+          return record
+        end
 
         if geoip.found? then
           if @continent then
@@ -343,7 +350,7 @@ module Fluent
             end
           end
 
-          log.info "Record: %s" % record.inspect
+          log.debug "Record: %s" % record.inspect
         else
           log.warn "It was not possible to look up the #{ip}."
         end


### PR DESCRIPTION
I also change the record log level to avoid the large number of logs.

Besides, there is also an option that to provide a boolean configuration say "ignore_invalid_ip" to let the user decides whether to ignore it or not.
