### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-filter-geoip.gemspec
+++ b/fluent-plugin-filter-geoip.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'fluentd', '~> 0.12.32'
+  spec.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 2']
   spec.add_runtime_dependency 'maxminddb', '~> 0.1.11'
 
-  spec.add_development_dependency 'bundler', '~> 1.14.6'
+  spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 11.1.2'
   spec.add_development_dependency 'test-unit', '~> 3.1.5'
   spec.add_development_dependency 'minitest', '~> 5.8.3'

--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -2,8 +2,9 @@ require 'maxminddb'
 require 'json'
 require 'fileutils'
 require 'open-uri'
+require 'fluent/plugin/filter'
 
-module Fluent
+module Fluent::Plugin
   class GeoIPFilter < Filter
     Fluent::Plugin.register_filter('geoip', self)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,6 +16,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/filter'
 
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
@@ -30,4 +32,5 @@ end
 require 'fluent/plugin/filter_geoip'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end

--- a/test/plugin/test_filter_geoip.rb
+++ b/test/plugin/test_filter_geoip.rb
@@ -32,8 +32,8 @@ class SolrOutputTest < Test::Unit::TestCase
     connection_type true
   ]
 
-  def create_driver(conf=CONFIG, tag='test')
-    Fluent::Test::FilterTestDriver.new(Fluent::GeoIPFilter, tag).configure(conf)
+  def create_driver(conf=CONFIG)
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::GeoIPFilter).configure(conf)
   end
 
   def test_configure
@@ -59,17 +59,15 @@ class SolrOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG)
     host = '212.99.123.25'
 
-    d.run do
-      d.emit({'host' => host})
+    d.run(default_tag: 'test') do
+      d.feed({'host' => host})
     end
 
-    emits = d.emits
+    emits = d.filtered
 
     assert_equal 1, emits.length
 
-    assert_equal 'test', emits[0][0]
-
-    h = emits[0][2]
+    h = emits[0][1]
 
     assert_equal 'EU', h['geoip.continent.code']
     assert_equal 6255148, h['geoip.continent.geoname_id']


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
Using v0.14 API permits to handle nanosecond precision time in event.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.